### PR TITLE
Remove deprecated `createJSModules` method

### DIFF
--- a/android/src/main/java/fr/aybadb/rnak/RNAKPackage.java
+++ b/android/src/main/java/fr/aybadb/rnak/RNAKPackage.java
@@ -1,7 +1,6 @@
 package fr.aybadb.rnak;
 
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
@@ -16,11 +15,6 @@ import java.util.List;
 public class RNAKPackage implements ReactPackage {
 	@Override
 	public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
-		return Collections.emptyList();
-	}
-
-	@Override
-	public List<Class<? extends JavaScriptModule>> createJSModules() {
 		return Collections.emptyList();
 	}
 


### PR DESCRIPTION
React Native v0.47 removes the `createJSModules` method. The library wasn't compiling due to this issue.